### PR TITLE
Implement normalized stat bars, change max stat value to 255

### DIFF
--- a/format/render.go
+++ b/format/render.go
@@ -6,6 +6,15 @@ import (
 	"strings"
 )
 
+var StatOrder = []string{
+	"hp",
+	"attack",
+	"defense",
+	"special-attack",
+	"special-defense",
+	"speed",
+}
+
 func PrintPokemonSummary(summary api.PokemonSummary) {
 	fmt.Printf("%s (ID: %d)\n", summary.Name, summary.ID)
 	fmt.Println("==============================")
@@ -25,7 +34,8 @@ func PrintDetailedPokemonSummary(summary api.PokemonSummary, fullMoveset bool) {
 	fmt.Printf("Abilities: %s\n", AbilitiesDisplay(summary.Abilities))
 
 	fmt.Println("\nStats:")
-	for stat, value := range summary.Stats {
+	for _, stat := range StatOrder {
+		value := summary.Stats[stat]
 		bar := StatBar(value)
 		fmt.Printf("  %-15s %3d %s\n", stat, value, bar)
 	}

--- a/format/transformations.go
+++ b/format/transformations.go
@@ -26,8 +26,12 @@ func HeightToString(height int) string {
 }
 
 func StatBar(value int) string {
-	barLength := value / 10
-	return "[" + strings.Repeat("█", barLength) + strings.Repeat(" ", 10-barLength) + "]"
+	const maxStatValue = 255
+	const maxBarLength = 25
+
+	normalizedBarLength := int(float64(value) / float64(maxStatValue) * float64(maxBarLength))
+
+	return "[" + strings.Repeat("█", normalizedBarLength) + strings.Repeat(" ", maxBarLength-normalizedBarLength) + "]"
 }
 
 func TypesDisplay(types []string) string {


### PR DESCRIPTION
Closes #1 

Stat bar max width can be modified, max stat value changed to 255.

Bar length is based on a pokemon's stat value normalized to max bar length and max stat value.

